### PR TITLE
LocalStorageで保存できるように実装

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,7 @@
 
 import { Task } from "../components/Task";
 
-import { useState } from "react";
+import { useState, useEffect} from "react";
 // Reactのstate管理フックをインポート
 
 import TaskForm from "../components/TaskForm";
@@ -73,6 +73,25 @@ export default function Home() {
 
 };
 
+// 初回ロード時にLocalStorageからタスクを取得
+useEffect(() => {
+
+  const savedTasks = localStorage.getItem("tasks");
+  // LocalStorageからtasksを取得
+
+  if (savedTasks) {
+    setTasks(JSON.parse(savedTasks));
+    // JSON文字列を配列に戻してstateにセット
+  }
+
+}, []);
+
+// tasks変更時にLocalStorageへ保存
+  useEffect(() => {
+
+    localStorage.setItem("tasks", JSON.stringify(tasks));
+
+  }, [tasks]);
 
 
   return (


### PR DESCRIPTION
## 概要
ブラウザリロード時にタスクデータが消えてしまう問題を解消するため、
useEffect を用いて tasks の状態を LocalStorage に保存する処理を実装しました。

## 変更内容
- tasks の状態を LocalStorage に保存する処理を追加
- 初回ロード時に LocalStorage からタスクを取得する処理を追加

## 期待する動作
- ページを更新してもタスクデータが保持される