### PR TITLE
学習ログをLocalStorageで保存できるように設定

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -163,6 +163,9 @@ export default function Home() {
   // 全タスク数
   const totalTaskCount = tasks.length;
 
+
+  // -------------------- tasks --------------------
+
   // 初回ロード時にLocalStorageからタスクを取得
   useEffect(() => {
     const savedTasks = localStorage.getItem("tasks");
@@ -178,6 +181,21 @@ export default function Home() {
   useEffect(() => {
     localStorage.setItem("tasks", JSON.stringify(tasks));
   }, [tasks]);
+
+// -------------------- studyLogs --------------------
+
+// 初回ロード時にLocalStorageから学習ログを取得
+useEffect(() => {
+  const savedLogs = localStorage.getItem("studyLogs");
+  if (savedLogs) {
+    setStudyLogs(JSON.parse(savedLogs));
+  }
+}, []);
+
+// studyLogs変更時にLocalStorageへ保存
+useEffect(() => {
+  localStorage.setItem("studyLogs", JSON.stringify(studyLogs));
+}, [studyLogs]);
 
   return (
     <main className="min-h-screen flex items-center justify-center bg-gray-100">


### PR DESCRIPTION
# 概要

ブラウザ更新時に学習時間がリセットされる問題を修正しました。


# 修正内容
	•	学習ログ（studyLogs）をLocalStorageに保存する処理を追加
	•	初回ロード時にLocalStorageから学習ログを復元する処理を追加

# 実装方法（概要）
	•	useEffect を用いて、studyLogsの変更時にLocalStorageへ保存
	•	初回レンダリング時にLocalStorageからデータを取得し、stateに反映
	
# 期待される効果

修正前
```
ブラウザ更新時に学習時間がリセットされる
```

修正後
```
ブラウザ更新後も学習時間が保持される
```

