### PR TITLE
fix: タスク完了チェック機能ボタン 復旧

### DIFF
--- a/components/TaskItem.tsx
+++ b/components/TaskItem.tsx
@@ -21,6 +21,7 @@ export default function TaskItem({
   task,
   deleteTask,
   updateTask,
+  toggleTask,
   addStudyLog,
   fetchTasks,
   fetchStudyLogs,
@@ -121,6 +122,13 @@ export default function TaskItem({
                 options={uniqueTags}
               />
             </div>
+
+             {/* タスク完了チェック */}
+            <input
+              type="checkbox"
+              checked={task.done}
+              onChange={() => toggleTask(task.id)}
+            />
 
             <button onClick={handleSave} className="text-green-500 ml-2">
               保存


### PR DESCRIPTION
TaskItem.tsxの以下の部分を消したので復旧
```
 {/* タスク完了チェック */}
            <input
              type="checkbox"
              checked={task.done}
              onChange={() => toggleTask(task.id)}
            />
 ```