### PR TITLE
デザインを設定

### DIFF
--- a/components/Chart.tsx
+++ b/components/Chart.tsx
@@ -11,16 +11,17 @@ import {
   XAxis,
   YAxis,
   CartesianGrid,
+  ResponsiveContainer,
 } from "recharts";
 
-// グラフで使う色の一覧
+// グラフで使う色の一覧（ネイビー・ブルー系で統一）
 const COLORS = [
-  "#6366f1", // インディゴ（青系・メイン）
-  "#22c55e", // グリーン（成功・成長）
-  "#f59e0b", // アンバー（注意・中間）
-  "#ef4444", // レッド（強調）
-  "#8b5cf6", // パープル（補助）
-  "#06b6d4", // シアン（アクセント）
+  "#1e40af", // ディープブルー
+  "#3b82f6", // ブルー
+  "#60a5fa", // ライトブルー
+  "#1d4ed8", // ネイビー
+  "#6366f1", // インディゴ
+  "#93c5fd", // ペールブルー
 ];
 
 // props型
@@ -34,69 +35,61 @@ type Props = {
 export default function Chart({ data, todayData }: Props) {
 
   return (
-    <div>
+    <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-6 space-y-6">
 
       {/* ===== 今日の学習割合（円グラフ） ===== */}
-      <h2 className="text-lg font-bold mt-6 mb-2 text-center">今日の学習割合</h2>
-
-      {/* 今日のデータがない場合はメッセージを表示 */}
-      {todayData.length === 0 ? (
-        <p className="text-center text-gray-400 text-sm mb-4">今日の学習記録がありません</p>
-      ) : (
-        <PieChart width={300} height={280}>
-
-          {/* 円グラフ本体 */}
-          <Pie
-            data={todayData}
-            dataKey="value"
-            nameKey="name"
-            outerRadius={90}
-          >
-            {/* 各スライスに色を割り当てる */}
-            {todayData.map((_, index) => (
-              <Cell key={index} fill={COLORS[index % COLORS.length]} />
-            ))}
-          </Pie>
-
-          {/* ホバーで詳細表示（valueはundefinedの可能性があるため ?? で安全に表示） */}
-          <Tooltip formatter={(value) => `${value ?? 0} 分`} />
-
-          {/* 凡例 */}
-          <Legend />
-
-        </PieChart>
-      )}
+      <div>
+        <h2 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-3">今日の学習割合</h2>
+        {todayData.length === 0 ? (
+          <p className="text-center text-gray-400 text-sm py-6">今日の学習記録がありません</p>
+        ) : (
+          <ResponsiveContainer width="100%" height={220}>
+            <PieChart>
+              <Pie
+                data={todayData}
+                dataKey="value"
+                nameKey="name"
+                outerRadius={75}
+                strokeWidth={0}
+              >
+                {todayData.map((_, index) => (
+                  <Cell key={index} fill={COLORS[index % COLORS.length]} />
+                ))}
+              </Pie>
+              <Tooltip
+                formatter={(value) => `${value ?? 0} 分`}
+                contentStyle={{ borderRadius: "8px", border: "1px solid #e2e8f0", fontSize: "12px" }}
+              />
+              <Legend iconSize={10} wrapperStyle={{ fontSize: "11px" }} />
+            </PieChart>
+          </ResponsiveContainer>
+        )}
+      </div>
 
       {/* ===== 累計学習時間（棒グラフ） ===== */}
-      <h2 className="text-lg font-bold mt-4 mb-2 text-center">累計学習時間</h2>
-
-      {/* 累計データがない場合はメッセージを表示 */}
-      {data.length === 0 ? (
-        <p className="text-center text-gray-400 text-sm mb-4">学習記録がありません</p>
-      ) : (
-        <BarChart width={300} height={250} data={data} margin={{ top: 5, right: 10, left: 0, bottom: 5 }}>
-
-          {/* 背景のグリッド線 */}
-          <CartesianGrid strokeDasharray="3 3" />
-
-          {/* X軸：タグ名 */}
-          <XAxis dataKey="name" tick={{ fontSize: 12 }} />
-
-          {/* Y軸：分数 */}
-          <YAxis tick={{ fontSize: 12 }} />
-
-          {/* ホバーで詳細表示（valueはundefinedの可能性があるため ?? で安全に表示） */}
-          <Tooltip formatter={(value) => `${value ?? 0} 分`} />
-
-          {/* 棒グラフ本体：各タグごとに色を変える */}
-          <Bar dataKey="value" name="学習時間（分）" radius={[4, 4, 0, 0]}>
-            {data.map((_, index) => (
-              <Cell key={index} fill={COLORS[index % COLORS.length]} />
-            ))}
-          </Bar>
-
-        </BarChart>
-      )}
+      <div>
+        <h2 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-3">累計学習時間</h2>
+        {data.length === 0 ? (
+          <p className="text-center text-gray-400 text-sm py-6">学習記録がありません</p>
+        ) : (
+          <ResponsiveContainer width="100%" height={180}>
+            <BarChart data={data} margin={{ top: 5, right: 10, left: -10, bottom: 5 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#f1f5f9" />
+              <XAxis dataKey="name" tick={{ fontSize: 11, fill: "#94a3b8" }} axisLine={false} tickLine={false} />
+              <YAxis tick={{ fontSize: 11, fill: "#94a3b8" }} axisLine={false} tickLine={false} />
+              <Tooltip
+                formatter={(value) => `${value ?? 0} 分`}
+                contentStyle={{ borderRadius: "8px", border: "1px solid #e2e8f0", fontSize: "12px" }}
+              />
+              <Bar dataKey="value" name="学習時間（分）" radius={[4, 4, 0, 0]}>
+                {data.map((_, index) => (
+                  <Cell key={index} fill={COLORS[index % COLORS.length]} />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </div>
 
     </div>
   );

--- a/components/ClientApp.tsx
+++ b/components/ClientApp.tsx
@@ -257,45 +257,59 @@ useEffect(() => {
 
 
   return (
-    <main className="min-h-screen flex items-center justify-center bg-gray-100">
-      {/* アプリ全体のカードUI */}
-      <div className="bg-white p-8 rounded-xl shadow-md w-[400px]">
-        {/* タイトル */}
-        <h1 className="text-2xl font-bold mb-6 text-center">Study Tracker</h1>
+    <main className="min-h-screen bg-gray-50">
+      {/* ヘッダー */}
+      <header className="bg-slate-800 px-6 py-4">
+        <div className="max-w-6xl mx-auto">
+          <h1 className="text-xl font-bold text-white tracking-tight">Study Tracker</h1>
+        </div>
+      </header>
 
-        {/* ダッシュボード */}
-        <Dashboard
-          overallMinutes={overallMinutes}
-          todayMinutes={todayMinutes}
-          completedTaskCount={completedTaskCount}
-          totalTaskCount={totalTaskCount}
-        />
+      {/* メインコンテンツ */}
+      <div className="max-w-6xl mx-auto px-4 py-8">
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
 
-        {/* タスク入力フォーム */}
-        <TaskForm
-          task={task}
-          setTask={setTask}
-          tag={tag}
-          setTag={setTag}
-          uniqueTags={uniqueTags}
-          addTask={addTask}
-        />
+          {/* 左カラム：フォーム・タスク一覧 */}
+          <div className="lg:col-span-2 space-y-6">
+            {/* タスク入力フォーム */}
+            <TaskForm
+              task={task}
+              setTask={setTask}
+              tag={tag}
+              setTag={setTag}
+              uniqueTags={uniqueTags}
+              addTask={addTask}
+            />
 
-        {/* タスク一覧 */}
-        <TaskList
-          tasks={tasks}
-          deleteTask={deleteTask}
-          updateTask={updateTask}
-          toggleTask={toggleTask}
-          studyLogs={studyLogs}
-          setStudyLogs={setStudyLogs}
-          fetchTasks={fetchTasks}
-          fetchStudyLogs={fetchStudyLogs}
-          uniqueTags={uniqueTags}
-          createStudyLog={addStudyLog}
-        />
+            {/* タスク一覧 */}
+            <TaskList
+              tasks={tasks}
+              deleteTask={deleteTask}
+              updateTask={updateTask}
+              toggleTask={toggleTask}
+              studyLogs={studyLogs}
+              setStudyLogs={setStudyLogs}
+              fetchTasks={fetchTasks}
+              fetchStudyLogs={fetchStudyLogs}
+              uniqueTags={uniqueTags}
+              createStudyLog={addStudyLog}
+            />
+          </div>
 
-        <Chart data={chartData} todayData={todayChartData} />
+          {/* 右カラム：ダッシュボード・グラフ */}
+          <div className="space-y-6">
+            {/* ダッシュボード */}
+            <Dashboard
+              overallMinutes={overallMinutes}
+              todayMinutes={todayMinutes}
+              completedTaskCount={completedTaskCount}
+              totalTaskCount={totalTaskCount}
+            />
+
+            <Chart data={chartData} todayData={todayChartData} />
+          </div>
+
+        </div>
       </div>
     </main>
   );

--- a/components/DashBoard.tsx
+++ b/components/DashBoard.tsx
@@ -21,36 +21,54 @@ export default function Dashboard({
 
 
   return (
+    <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-6">
+      <h2 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-4">概要</h2>
 
-    // カードレイアウト（2列）
-    <div className="grid grid-cols-2 gap-4 mb-6">
+      <div className="grid grid-cols-2 gap-3">
 
-      {/* 全体学習時間 */}
-      <div className="bg-blue-100 p-4 rounded">
-        <p className="text-sm">総学習時間</p>
-        <p className="text-xl font-bold">{overallMinutes} 分</p>
+        {/* 総学習時間 */}
+        <div className="p-4 bg-indigo-50 rounded-lg border-l-4 border-indigo-400">
+          <p className="text-xs font-medium text-indigo-500 mb-1">総学習時間</p>
+          <p className="text-2xl font-bold text-slate-800">
+            {overallMinutes}
+            <span className="text-sm font-normal text-slate-400 ml-1">分</span>
+          </p>
+        </div>
+
+        {/* 今日の学習時間 */}
+        <div className="p-4 bg-blue-50 rounded-lg border-l-4 border-blue-500">
+          <p className="text-xs font-medium text-blue-500 mb-1">今日の学習</p>
+          <p className="text-2xl font-bold text-slate-800">
+            {todayMinutes}
+            <span className="text-sm font-normal text-slate-400 ml-1">分</span>
+          </p>
+        </div>
+
+        {/* 完了タスク */}
+        <div className="p-4 bg-emerald-50 rounded-lg border-l-4 border-emerald-400">
+          <p className="text-xs font-medium text-emerald-600 mb-1">完了タスク</p>
+          <p className="text-2xl font-bold text-slate-800">
+            {completedTaskCount}
+            <span className="text-sm font-normal text-slate-400 ml-1">/ {totalTaskCount}</span>
+          </p>
+        </div>
+
+        {/* 達成率 */}
+        <div className="p-4 bg-violet-50 rounded-lg border-l-4 border-violet-400">
+          <p className="text-xs font-medium text-violet-500 mb-1">達成率</p>
+          <p className="text-2xl font-bold text-slate-800">
+            {completionRate}
+            <span className="text-sm font-normal text-slate-400 ml-1">%</span>
+          </p>
+          <div className="mt-2 h-1.5 bg-violet-100 rounded-full overflow-hidden">
+            <div
+              className="h-1.5 bg-violet-400 rounded-full transition-all"
+              style={{ width: `${completionRate}%` }}
+            />
+          </div>
+        </div>
+
       </div>
-
-      {/* 今日の学習時間 */}
-      <div className="bg-green-100 p-4 rounded">
-        <p className="text-sm">今日の学習時間</p>
-        <p className="text-xl font-bold">{todayMinutes} 分</p>
-      </div>
-
-      {/* 完了タスク */}
-      <div className="bg-yellow-100 p-4 rounded">
-        <p className="text-sm">完了タスク</p>
-        <p className="text-xl font-bold">
-          {completedTaskCount} / {totalTaskCount}
-        </p>
-      </div>
-
-      {/* 達成率 */}
-      <div className="bg-purple-100 p-4 rounded">
-        <p className="text-sm">達成率</p>
-        <p className="text-xl font-bold">{completionRate}%</p>
-      </div>
-
     </div>
   );
 }

--- a/components/TagInput.tsx
+++ b/components/TagInput.tsx
@@ -18,20 +18,28 @@ export default function TagInput({
   // ドロップダウン表示状態
   const [isOpen, setIsOpen] = useState(false);
 
+  // フィルタ用の検索テキスト（value とは独立して管理）
+  // フォーカス時にリセットすることで、編集画面でも全タグを表示できる
+  const [searchText, setSearchText] = useState("");
+
   return (
     <div className="relative">
       {/* 入力フィールド */}
       <input
         type="text"
-        value={value} // 入力値を表示
+        value={value} // 表示は選択済みの value を使う
         onChange={(e) => {
           onChange(e.target.value); // 親に値を渡す
-          setIsOpen(true); // 入力したら候補を表示
+          setSearchText(e.target.value); // フィルタも同期
+          setIsOpen(true);
         }}
         placeholder={placeholder}
-        className="flex-1 px-2 py-2"
-        onFocus={() => setIsOpen(true)} // フォーカスで開く
-        onBlur={() => setTimeout(() => setIsOpen(false), 100)} 
+        className="flex-1 px-2 py-2 w-full"
+        onFocus={() => {
+          setSearchText(""); // フォーカス時にフィルタをリセット → 全件表示
+          setIsOpen(true);
+        }}
+        onBlur={() => setTimeout(() => setIsOpen(false), 100)}
         // blurですぐ閉じるとクリックできないので少し遅らせる
       />
 
@@ -40,15 +48,16 @@ export default function TagInput({
         <div className="absolute top-full left-0 w-full bg-white border rounded shadow-md mt-1 z-10">
 
           {options
-            // 入力内容でフィルタリング（部分一致）
+            // searchText でフィルタリング（value ではなく入力中の文字列で絞る）
             .filter((t) =>
-              t.toLowerCase().includes(value.toLowerCase())
+              t.toLowerCase().includes(searchText.toLowerCase())
             )
             .map((t) => (
               <div
-                key={t} // 一意のキー
+                key={t}
                 onMouseDown={() => {
                   onChange(t); // 候補を選択
+                  setSearchText(""); // フィルタをリセット
                   setIsOpen(false); // ドロップダウン閉じる
                 }}
                 className="px-3 py-2 hover:bg-gray-100 cursor-pointer"

--- a/components/TaskForm.tsx
+++ b/components/TaskForm.tsx
@@ -15,46 +15,37 @@ type Props = {
 export default function TaskForm({ task, setTask, addTask, tag, setTag, uniqueTags }: Props) {
 
   return (
+    <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-6">
+      <h2 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-4">タスクを追加</h2>
 
-    // タスク入力エリア
-    <div className="mb-6">
-
-      <div className="flex border rounded">
-
-      {/* タスク入力フォーム */}
-      <input
-        type="text"
-        value={task}
-        // 入力フォームの値をstateと同期
-
-        onChange={(e) => setTask(e.target.value)}
-        // 入力された文字をtask stateに保存
-
-        placeholder="タスクを入力"
-
-        className="flex-1 px-2 py-2 outline-none"
-      />
-
-      {/* タグ入力フォーム */}
-      <div className="w-40 border-l">
-        <TagInput
-          value={tag}
-          onChange={setTag}
-          options={uniqueTags}
+      <div className="space-y-3">
+        {/* タスク入力フォーム */}
+        <input
+          type="text"
+          value={task}
+          onChange={(e) => setTask(e.target.value)}
+          placeholder="タスクを入力"
+          className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm text-slate-700 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
         />
+
+        {/* タグ入力フォーム */}
+        <div className="border border-gray-200 rounded-lg">
+          <TagInput
+            value={tag}
+            onChange={setTag}
+            options={uniqueTags}
+          />
+        </div>
+
+        {/* タスク追加ボタン */}
+        <button
+          onClick={addTask}
+          className="w-full bg-blue-600 text-white py-2 rounded-lg text-sm font-medium hover:bg-blue-700 active:bg-blue-800 transition-colors"
+        >
+          追加
+        </button>
       </div>
-
     </div>
-
-      {/* タスク追加ボタン */}
-      <button
-        onClick={addTask}
-        className="bg-blue-500 text-white px-4 py-2 rounded"
-      >
-        追加
-      </button>
-    </div>
-
   );
 
 }

--- a/components/TaskItem.tsx
+++ b/components/TaskItem.tsx
@@ -95,91 +95,91 @@ export default function TaskItem({
   const taskTotalMinutes = task.totalMinutes ?? 0;
 
   return (
-    <li className="border p-3 rounded">
+    <li className="rounded-lg border border-gray-200 p-4 hover:border-blue-200 hover:shadow-sm transition-all">
       {isEditing ? (
-        <>
-          {/* 編集入力フォーム */}
-          <div className="flex flex-wrap items-center gap-2 w-full">
-            {/* 編集時タスク入力 */}
+        <div className="space-y-3">
+          {/* 編集フォーム */}
+          <div className="flex gap-2">
             <input
               value={editTask}
               onChange={(e) => setEditTask(e.target.value)}
-              className="border px-2 py-1"
+              className="flex-1 border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
-
-            {/* 学習時間入力 */}
             <input
               type="number"
               value={minutes}
               onChange={(e) => setMinutes(e.target.value)}
               placeholder="分"
-              className="border px-2 py-1 w-20"
+              className="w-20 border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
+          </div>
 
-            {/* タグ候補ドロップダウン */}
-            <div className="border rounded">
-              <TagInput
-                value={editTag}
-                onChange={setEditTag}
-                options={uniqueTags}
+          <div className="border border-gray-200 rounded-lg">
+            <TagInput
+              value={editTag}
+              onChange={setEditTag}
+              options={uniqueTags}
+            />
+          </div>
+
+          <div className="flex items-center gap-3">
+            <label className="flex items-center gap-2 text-sm text-slate-600 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={task.done}
+                onChange={() => toggleTask(task.id)}
+                className="rounded"
               />
-            </div>
-
-             {/* タスク完了チェック */}
-            <input
-              type="checkbox"
-              checked={task.done}
-              onChange={() => toggleTask(task.id)}
-            />
-
-            <button onClick={handleSave} className="text-green-500 ml-2">
+              完了
+            </label>
+            <button
+              onClick={handleSave}
+              className="bg-blue-600 text-white text-sm px-4 py-1.5 rounded-lg hover:bg-blue-700 transition-colors"
+            >
               保存
             </button>
-
-            {/* 削除ボタン */}
-
             <button
               onClick={() => deleteTask(task.id)}
-              className="text-red-500 ml-2"
+              className="text-sm px-4 py-1.5 rounded-lg border border-red-200 text-red-500 hover:bg-red-50 transition-colors"
             >
               削除
             </button>
           </div>
-        </>
+        </div>
       ) : (
-        <>
-          <div className="flex justify-between items-center w-full">
-            {/* タスク表示 */}
-
-            <span className={task.done ? "line-through text-gray-400" : ""}>
-              {task.text} ({task.tag})（合計: {taskTotalMinutes}分）
+        <div className="flex justify-between items-start">
+          <div className="flex-1 min-w-0">
+            <span className={`text-sm font-medium block ${task.done ? "line-through text-gray-400" : "text-slate-700"}`}>
+              {task.text}
             </span>
+            <div className="flex items-center gap-2 mt-1.5">
+              <span className="text-xs bg-blue-50 text-blue-600 px-2 py-0.5 rounded-full font-medium border border-blue-100">
+                {task.tag}
+              </span>
+              <span className="text-xs text-slate-400">{taskTotalMinutes} 分</span>
+            </div>
+          </div>
 
+          <div className="flex items-center gap-1 ml-3 shrink-0">
             <button
               onClick={() => {
-                // 編集モードに切り替え
-                setIsEditing(true)
-                // 編集用stateに現在の値をセット
+                setIsEditing(true);
                 setEditTask(task.text);
                 setEditTag(task.tag);
                 setMinutes(taskTotalMinutes.toString());
-              }
-              }
-              className="text-blue-500 ml-2"
+              }}
+              className="text-xs text-slate-400 hover:text-blue-600 px-2 py-1 rounded hover:bg-blue-50 transition-colors"
             >
               編集
             </button>
-
-            {/* 削除ボタン */}
-
             <button
               onClick={() => deleteTask(task.id)}
-              className="text-red-500 ml-2"
+              className="text-xs text-slate-400 hover:text-red-500 px-2 py-1 rounded hover:bg-red-50 transition-colors"
             >
               削除
             </button>
           </div>
-        </>
+        </div>
       )}
     </li>
   );

--- a/components/TaskList.tsx
+++ b/components/TaskList.tsx
@@ -29,8 +29,9 @@ export default function TaskList({
   createStudyLog,
 }: Props) {
   return (
-    // タスク一覧
-    <ul className="space-y-2">
+    <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-6">
+      <h2 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-4">タスク一覧</h2>
+      <ul className="space-y-2">
       {tasks.map((task: any) => (
         // tasks配列をループして表示
 
@@ -70,6 +71,7 @@ export default function TaskList({
 
         />
       ))}
-    </ul>
+      </ul>
+    </div>
   );
 }


### PR DESCRIPTION
## 概要

  編集画面でタグのドロップダウンに全タグが表示されないバグを修正し、                                                                  
  あわせてアプリ全体のレイアウト・デザインを大幅に改修しました。
                                                                                                                                      
  ---             
                                                                                                                                      
  ## バグ修正：編集画面のタグドロップダウン（TagInput.tsx）                                                                           
   
  **問題**                                                                                                                            
  編集画面でドロップダウンを開くと、現在選択中のタグ1件しか表示されない
                                                                                                                                      
  **原因**                                                                                                                            
  フィルタリングに `value`（現在選択中のタグ名）を使っていたため、                                                                    
  編集画面では常に1件に絞り込まれていた                                                                                               
                                                                                                                                      
  **修正内容**                                                                                                                        
  - フィルタ専用の `searchText` state を独立して追加                                                                                  
  - フォーカス時に `searchText` をリセットすることで、                                                                                
    編集画面でも全タグが一覧表示されるようにした                                                                                      
  - `value` と `defaultValue` の違いを考慮した実装に統一                                                                              
                                                                                                                                      
  ---                                                                                                                                 
                                                                                                                                      
  ## レイアウト全体改修

  **全体構成の変更（ClientApp.tsx）**                                                                                                 
  - 従来：中央寄せの単一カード（幅400px固定）
  - 変更後：最大幅6xl・3カラムグリッドのサイドバー型レイアウト                                                                        
    - 左（2/3）：タスク入力フォーム + タスク一覧                                                                                      
    - 右（1/3）：ダッシュボード + グラフ                                                                                              
  - ヘッダーバーを新設（`bg-slate-800` のナビゲーションバー）                                                                         
                                                                                                                                      
  **各コンポーネントのUI統一**                                                                                                        
  - DashBoard・TaskList・Chart：カードUI（`rounded-xl` / `border` / `shadow-sm`）に統一し、セクションヘッダーを追加                   
  - TaskItem：ホバー時のボーダー変化・シャドウアニメーションを追加                                                                    
  - グラフ：カラーパレットをネイビー・ブルー系に統一、`ResponsiveContainer` でレスポンシブ対応                                        
                                                                                                                                      
  ---                                                                                                                                 
                                                                                                                                      
        
                                              