### PR TITLE
TypeErrorの不具合修正

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -10,11 +10,9 @@ export default async function Page() {
     // ローカル → Prisma
     tasks = await getTasksServer();
   } else {
-    // 本番 → API経由（Supabase）
-    const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/tasks`, {
-      cache: "no-store",
-    });
-    tasks = await res.json();
+    // 本番 → Server ComponentはAuthトークンを持てないため空配列で初期化
+    // ClientApp内のuseEffectで認証後にデータ取得する
+    tasks = [];
   }
 
   return(

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -39,6 +39,7 @@ export async function getTasks() {
 export async function createTask(text: string, tag: string) {
   // 追加する関数
   const { data: { session } } = await supabase.auth.getSession();
+  if (!session) throw new Error("Not authenticated");
   if (isLocal) {
     await fetch("/api/tasks", {
       method: "POST",
@@ -51,12 +52,21 @@ export async function createTask(text: string, tag: string) {
     return;
   }
 
+  const { data: dbUser, error: userError } = await supabase
+    .from("users")
+    .select("id")
+    .eq("supabase_id", session.user.id)
+    .single();
+
+  if (userError || !dbUser) throw new Error("User not found");
+
   const { data, error } = await supabase.from("tasks").insert({
     text,
     tag,
     done: false,
     total_minutes: 0,
     date: new Date().toISOString(),
+    user_id: dbUser.id,
   });
 
   if (error) throw error;


### PR DESCRIPTION
# 🎯 概要

Supabase認証対応に伴い、タスク取得・作成処理の不具合を修正しました。
あわせて、認証付きAPIの呼び出しタイミングを見直し、安定したデータ取得ができるように改善しました。


# 🧩 背景 / 課題

以下の問題が発生していました：
	•	本番環境で /api/tasks が401を返却
	•	フロントで map is not a function エラーが発生
	•	タスク作成後に一覧に反映されない

# 🔍 原因

主に以下の2点が原因でした：

① Server Componentで認証付きAPIを呼び出していた
	•	Server ComponentではAuthorizationヘッダーを付与できない
	•	/api/tasks が401となり、エラーレスポンスが返却されていた


② user_idの不一致
	•	Supabase Authの user.id はUUID
	•	DBの tasks.user_id はInt（PrismaのUser.id）

そのため：

⭕️Supabase user.id（UUID）
❌tasks.user_id（Int）


# 🛠 修正内容

① データ取得の責務をClient側に移動
	•	Server Componentでの /api/tasks 呼び出しを廃止
	•	Client Componentの useEffect 内で getTasks() を実行


② createTask時にuser_idを正しく設定
	•	users テーブルから supabase_id → id（Int） を取得
	•	tasks作成時に user_id を設定


③ APIのレスポンスを安定化
	•	エラー時やデータ未取得時は空配列を返却

if (error || !data) {
  return Response.json([], { status: 200 });
}


# 💡 補足
	•	認証付きAPIはClient側で呼び出す設計に統一
	•	Supabase Auth IDとDBのUser IDを明確に分離


