### PR TITLE
他の該当ファイルでsnake_caseからcamelCaseに変更

### DIFF
--- a/app/api/study-logs/route.ts
+++ b/app/api/study-logs/route.ts
@@ -106,16 +106,17 @@ export async function POST(req: Request) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const dbUser = await prisma.user.findUnique({
-    where: { supabaseId: user.id },
-  });
-
-  if (!dbUser) {
-    return Response.json({ error: "User not found" }, { status: 404 });
-  }
   const body = await req.json();
 
   if (isLocal) {
+    const dbUser = await prisma.user.findUnique({
+      where: { supabaseId: user.id },
+    });
+
+    if (!dbUser) {
+      return Response.json({ error: "User not found" }, { status: 404 });
+    }
+
     const log = await prisma.studyLog.create({
       data: {
         taskId: BigInt(body.taskId),
@@ -135,11 +136,21 @@ export async function POST(req: Request) {
   }
 
   // 本番（Supabase）
+  const { data: dbUser, error: userError } = await supabase
+    .from("users")
+    .select("id")
+    .eq("supabaseId", user.id)
+    .single();
+
+  if (userError || !dbUser) {
+    return Response.json({ error: "User not found" }, { status: 404 });
+  }
+
   const { data, error } = await supabase.from("study_logs").insert({
     taskId: body.taskId,
     minutes: body.minutes,
     date: new Date().toISOString(),
-    userId: dbUser.id
+    userId: dbUser.id,
   });
 
   if (error) {

--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -142,13 +142,23 @@ export async function POST(req: Request) {
   const body = await req.json();
 
   // 🔥 本番
+  const { data: dbUser, error: userError } = await supabase
+    .from("users")
+    .select("id")
+    .eq("supabaseId", user.id)
+    .single();
+
+  if (userError || !dbUser) {
+    return Response.json({ error: "User not found" }, { status: 404 });
+  }
+
   const { data, error } = await supabase.from("tasks").insert({
     text: body.text,
     tag: body.tag,
     done: false,
     totalMinutes: 0,
     date: new Date().toISOString(),
-    userId: user.id,
+    userId: dbUser.id,
   });
 
   if (error) {

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -55,7 +55,7 @@ export async function createTask(text: string, tag: string) {
   const { data: dbUser, error: userError } = await supabase
     .from("users")
     .select("id")
-    .eq("supabase_id", session.user.id)
+    .eq("supabaseId", session.user.id)
     .single();
 
   if (userError || !dbUser) throw new Error("User not found");
@@ -64,9 +64,9 @@ export async function createTask(text: string, tag: string) {
     text,
     tag,
     done: false,
-    total_minutes: 0,
+    totalMinutes: 0,
     date: new Date().toISOString(),
-    user_id: dbUser.id,
+    userId: dbUser.id,
   });
 
   if (error) throw error;
@@ -122,7 +122,7 @@ export async function updateTaskDB(task: Task) {
       text: task.text,
       tag: task.tag,
       done: task.done,
-      total_minutes: task.totalMinutes,
+      totalMinutes: task.totalMinutes,
     })
     .eq("id", task.id);
 }
@@ -158,7 +158,7 @@ export async function createStudyLog(taskId: number, minutes: number) {
   }
 
   await supabase.from("study_logs").insert({
-    task_id: taskId,
+    taskId,
     minutes,
     date: new Date().toISOString(),
   });
@@ -182,5 +182,5 @@ export async function deleteStudyLogsByTask(taskId: number) {
   await supabase
     .from("study_logs")
     .delete()
-    .eq("task_id", taskId);
+    .eq("taskId", taskId);
 }


### PR DESCRIPTION
## 問題                                                   

  StudyLogのユーザー単位管理修正後に、タスク一覧・グラフが表示されなくなっていた。                                                    
  
  ## 原因                                                                                                                             
                                                            
  `lib/db.ts` の本番（Supabase直接操作）パスで、snake_caseのカラム名を使っていたため、                                                
  INSERTが失敗 or `userId` が NULL で保存されていた。
  GETは `userId = dbUser.id`（整数）でフィルタするため、マッチするレコードが0件になっていた。                                         
                                                                                                                                      
  また `tasks/route.ts` POSTでは `userId: user.id`（SupabaseのUUID文字列）を直接入れており、                                          
  GETのフィルタと値が食い違っていた。                                                                                                 
                                                                                                                                      
  さらに `study-logs/route.ts` POSTでは Prisma呼び出しが `isLocal` チェックの外にあり、                                               
  本番でも Prismaを呼んで 404 を返していた。
                                                                                                                                      
  ## 修正内容                                               
                                                                                                                                      
  - `lib/db.ts`                                             
    - `createTask`: `supabase_id` → `supabaseId`、`user_id` → `userId`、`total_minutes` → `totalMinutes`
    - `updateTaskDB`: `total_minutes` → `totalMinutes`                                                                                
    - `createStudyLog`: `task_id` → `taskId`
    - `deleteStudyLogsByTask`: `task_id` → `taskId`                                                                                   
                                                            
  - `app/api/tasks/route.ts` POST（本番）                                                                                             
    - `userId: user.id`（UUID）→ usersテーブルから `dbUser` を取得して `userId: dbUser.id`（整数）に修正
                                                                                                                                      
  - `app/api/study-logs/route.ts` POST
    - Prisma呼び出しを `isLocal` ブロック内に移動                                                                                     
    - 本番パスで Supabaseから `dbUser` を正しく取得するよう修正
                                                                                                                                      
  ## 注意
                                                                                                                                      
  修正前のコードで作成されたタスク・ログは `userId` が NULL になっている可能性あり。                                                  
  その場合は Supabaseコンソールで確認・修正が必要。
                                                                                                                                      
  ```sql                                                    
  select * from tasks where "userId" is null;                                                                                         
  select * from study_logs where "userId" is null;          
```                     