### PR TITLE
StudyLogが本番環境で保存されない問題を修正（userId未設定）

### DIFF
--- a/components/TaskItem.tsx
+++ b/components/TaskItem.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Task, StudyLog } from './Types';
 import TagInput from "./TagInput";
 import { updateTaskDB } from "../lib/db";
-import { deleteStudyLogsByTask } from "@/lib/db";
+import { supabase } from "@/lib/supabase";
 
 // propsの型定義
 type Props = {
@@ -43,9 +43,15 @@ export default function TaskItem({
     // 学習時間を数値に変換
     const newMinutes = Number(minutes);
 
+
+    const { data: { session } } = await supabase.auth.getSession();
+
     // 前削除（このタスクの学習ログをすべて削除）
     await fetch(`/api/study-logs/${task.id}`, {
       method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${session?.access_token}`,
+    },
     });
 
      // 🔥 DB更新

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -161,10 +161,25 @@ export async function createStudyLog(taskId: number, minutes: number) {
     return;
   }
 
+  // 🔥 追加：ユーザー取得
+  const { data: { user } } = await supabase.auth.getUser();
+
+  // 🔥 usersテーブルからid取得
+  const { data: dbUser } = await supabase
+    .from("users")
+    .select("id")
+    .eq("supabaseId", user?.id)
+    .single();
+
+  if (!dbUser) throw new Error("User not found");
+
+
+  // 🔥 study_logsテーブルに挿入
   await supabase.from("study_logs").insert({
     taskId,
     minutes,
     date: new Date().toISOString(),
+    userId: dbUser.id
   });
 }
 


### PR DESCRIPTION
# ■ 概要

本番環境において、学習ログ（study_logs）が保存されていない問題を修正しました。


# ■ 問題

学習時間を入力しても、study_logsテーブルにデータが保存されず、グラフに反映されない状態になっていました。


# ■ 原因

本番環境では、study_logsへのINSERT時に userId が設定されていませんでした。


```
// 修正前

await supabase.from("study_logs").insert({
  taskId,
  minutes,
  date: new Date().toISOString(),
});
```

そのため、以下の問題が発生していました：
	•	userId が null の状態で保存される
	•	API側で .eq("userId", dbUser.id) による絞り込みが行われる
	•	結果として、該当ユーザーのログが取得できず空配列になる


# ■ 修正内容

本番環境でも userId を取得し、INSERT時に設定するように修正しました。


```
// 修正後
const { data: { user } } = await supabase.auth.getUser();

const { data: dbUser } = await supabase
  .from("users")
  .select("id")
  .eq("supabaseId", user?.id)
  .single();

await supabase.from("study_logs").insert({
  taskId,
  minutes,
  date: new Date().toISOString(),
  userId: dbUser.id, // 追加
});
```

# ■ 影響範囲
	•	StudyLogの保存処理（本番環境）
	•	グラフ表示（ユーザーごとの集計）


# ■ 動作確認
	•	学習時間を入力 → study_logsにデータが保存されることを確認
	•	グラフが正常に表示されることを確認
	•	ユーザーごとにデータが分離されることを確認


# ■ 補足

ローカル環境ではAPI経由で userId が設定されていたため、問題が顕在化していませんでした。


