### PR TITLE
専用ping APIを作成

### DIFF
--- a/app/api/ping/route.ts
+++ b/app/api/ping/route.ts
@@ -1,0 +1,14 @@
+// ping APIは、Supabaseへの接続が成功しているかを確認するためのエンドポイントです。
+import { createClient } from "@supabase/supabase-js";
+
+export async function GET() {
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  );
+
+  // 🔥 軽くDBアクセス（重要）
+  await supabase.from("tasks").select("id").limit(1);
+
+  return new Response("OK");
+}


### PR DESCRIPTION
# 概要

Supabaseの無料プランにおいて、一定期間アクセスがない場合にプロジェクトが自動停止する問題に対応するため、定期的にDBアクセスを発生させるping用APIエンドポイントを追加した。



# 背景

Supabaseは無料プランの場合、一定期間未使用状態が続くとプロジェクトが自動的にpaused状態となる仕様となっている。

本プロジェクトでも実際に以下の事象が発生した：
	•	StudyTrackerプロジェクトが自動停止
	•	手動でResumeが必要な状態になった

既存の /api/tasks エンドポイントは認証必須のため、cronなどの外部からの定期アクセスでは401エラーとなり、Supabaseへのアクセスが発生しない問題があった。



# 対応内容

以下の対応を実施：
	•	認証不要の /api/ping エンドポイントを新規追加
	•	軽量なDBアクセス（tasksテーブルへのselect）を実装
	•	Supabaseが「アクティブ」と判定される状態を維持できるようにした

```
import { createClient } from "@supabase/supabase-js";

export async function GET() {
  const supabase = createClient(
    process.env.NEXT_PUBLIC_SUPABASE_URL!,
    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
  );

  await supabase.from("tasks").select("id").limit(1);

  return new Response("OK");
}
```



期待される効果
	•	Supabaseプロジェクトの自動停止防止
	•	手動Resume対応の削減
	•	安定した開発・検証環境の維持



補足

本エンドポイントは cron-job.org 等の外部サービスから1日1回程度アクセスすることを想定している。



